### PR TITLE
Reference autoload directly rather than depending on drupal autoload.…

### DIFF
--- a/bin/drush.php
+++ b/bin/drush.php
@@ -81,6 +81,7 @@ if (!$drupalFinder->locateRoot($ROOT)) {
 }
 
 $drupalRoot = $drupalFinder->getDrupalRoot();
+$vendorRoot = $drupalFinder->getVendorDir();
 
 if ($DEBUG) {
   echo "DRUPAL ROOT: " . $drupalRoot . PHP_EOL;
@@ -90,7 +91,7 @@ if ($DEBUG) {
 
 chdir($drupalRoot);
 
-require_once $drupalRoot . '/autoload.php';
+require_once $vendorRoot . '/autoload.php';
 
 $methods = [
   'local' => [


### PR DESCRIPTION
Drush-shim fails on Drupal 7 sites as core doesn't have an `autoload.php` however as the vendor directory is know it can be referenced directly.
