### PR TITLE
Fix #5. Better message when Drupal site not found

### DIFF
--- a/bin/drush.php
+++ b/bin/drush.php
@@ -102,8 +102,8 @@ if ($DEBUG) {
 
 if (!$drupalFinder->locateRoot($ROOT)) {
   echo 'The Drush launcher could not find a Drupal site to operate on. Please do *one* of the following:' . PHP_EOL;
-  echo '  - Navigate to any where within yur Drupal project and try again.' . PHP_EOL;
-  echo '  - Add --root=/path/to/drush so Drush knows where your site is located.' . PHP_EOL;
+  echo '  - Navigate to any where within your Drupal project and try again.' . PHP_EOL;
+  echo '  - Add --root=/path/to/drupal so Drush knows where your site is located.' . PHP_EOL;
   echo '  - Add a site alias so Drush knows where your site is located.' . PHP_EOL;
   exit(1);
 }

--- a/bin/drush.php
+++ b/bin/drush.php
@@ -104,7 +104,7 @@ if (!$drupalFinder->locateRoot($ROOT)) {
   echo 'The Drush launcher could not find a Drupal site to operate on. Please do *one* of the following:' . PHP_EOL;
   echo '  - Navigate to any where within yur Drupal project and try again.' . PHP_EOL;
   echo '  - Add --root=/path/to/drush so Drush knows where your site is located.' . PHP_EOL;
-  echo '  - Add a site alias o Drush knows where your site is located.' . PHP_EOL;
+  echo '  - Add a site alias so Drush knows where your site is located.' . PHP_EOL;
   exit(1);
 }
 

--- a/bin/drush.php
+++ b/bin/drush.php
@@ -101,7 +101,10 @@ if ($DEBUG) {
 }
 
 if (!$drupalFinder->locateRoot($ROOT)) {
-  echo 'Could not find Drupal in the current path.' . PHP_EOL;
+  echo 'The Drush launcher could not find a Drupal site to operate on. Please do *one* of the following:' . PHP_EOL;
+  echo '  - Navigate to any where within yur Drupal project and try again.' . PHP_EOL;
+  echo '  - Add --root=/path/to/drush so Drush knows where your site is located.' . PHP_EOL;
+  echo '  - Add a site alias o Drush knows where your site is located.' . PHP_EOL;
   exit(1);
 }
 


### PR DESCRIPTION
In the message, I call this project the Drush launcher. If folks are agreeable to this name, I think we should change all UI to this name, and ideally change the repo name as well.